### PR TITLE
Enabled CI and added badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 2.2.0
+before_install: gem install bundler --version '>= 1.8.0'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Milc
 
+[![Gem Version](https://badge.fury.io/rb/milc.png)](https://rubygems.org/gems/milc)
+[![Build Status](https://travis-ci.org/groovenauts/milc.svg?branch=master)](https://travis-ci.org/groovenauts/milc)
+
 Milc means "Magellan Infrastructure Library and Command".
 
 This gem supports portability from command to ruby library in order to realize automated orchestration.


### PR DESCRIPTION
Enabled CI ([Travis CI](https://travis-ci.org/groovenauts/milc)),
and added gem version and build status badges in README.md.

Note: bundler gem in Travis CI is 1.7.9, 
which cannot satisfy build dependency.
(https://travis-ci.org/groovenauts/milc/builds/57906032#L95)
Added `gem install bundler --version ...` in .travis.yml (222c61f).
