### PR TITLE
quiet log of query command stdout

### DIFF
--- a/lib/milc/base.rb
+++ b/lib/milc/base.rb
@@ -28,8 +28,9 @@ module Milc
       Milc.logger
     end
 
-    def execute(cmd)
-      res = LoggerPipe.run(logger, cmd, dry_run: Milc.dry_run)
+    def execute(cmd, options = {})
+      options[:dry_run] = Milc.dry_run
+      res = LoggerPipe.run(logger, cmd, options)
       block_given? ? yield(res) : res
     end
 

--- a/lib/milc/dsl/ansible.rb
+++ b/lib/milc/dsl/ansible.rb
@@ -7,7 +7,8 @@ module Milc::Dsl
       # https://github.com/mitchellh/vagrant/blob/0098b7604d071948fd37b16dd10b87b6df49b624/plugins/provisioners/ansible/provisioner.rb#L58
       command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook #{cmd}"
       command << " -vvvv" if Milc.verbose
-      execute(command, &block)
+      execute(command, returns: :none, logging: :both, &block)
+      nil
     end
 
   end

--- a/lib/milc/dsl/gcloud.rb
+++ b/lib/milc/dsl/gcloud.rb
@@ -4,14 +4,19 @@ module Milc::Dsl
   module Gcloud
 
     def gcloud(cmd, &block)
-      cmd << " --project #{project}" unless cmd =~ /\s\-\-project[\s\=]/
-      execute("gcloud #{cmd}", &block)
+      execute(build_gcloud_command(cmd), returns: :none, logging: :both, &block)
     end
 
     def json_gcloud(cmd)
-      r = gcloud(cmd + " --format json")
+      r = execute(build_gcloud_command(cmd + " --format json"), returns: :stdout, logging: :stderr)
       res = r.nil? ? nil : JSON.parse(r)
       block_given? ? yield(res) : res
+    end
+
+    def build_gcloud_command(cmd)
+      r = "gcloud #{cmd}"
+      r << " --project #{project}" unless cmd =~ /\s\-\-project[\s\=]/
+      r
     end
 
   end

--- a/lib/milc/gcloud/backend/gcloud_command.rb
+++ b/lib/milc/gcloud/backend/gcloud_command.rb
@@ -9,8 +9,9 @@ module Milc
     module Backend
       class GcloudCommand
 
-        def execute(cmd)
-          res = LoggerPipe.run(Milc.logger, cmd, dry_run: Milc.dry_run)
+        def execute(cmd, options = {})
+          options[:dry_run] = Milc.dry_run
+          res = LoggerPipe.run(Milc.logger, cmd, options)
           block_given? ? yield(res) : res
         end
 

--- a/lib/milc/gcloud/resource.rb
+++ b/lib/milc/gcloud/resource.rb
@@ -48,10 +48,10 @@ module Milc
         @commands = commands || []
       end
 
-      def __gcloud(cmd, &block)
+      def __gcloud(cmd, options = {}, &block)
         c = "gcloud #{cmd} --format json"
         c << " --project #{project}" unless c =~ /\s\-\-project[\s\=]/
-        res = Gcloud.backend.execute(c, &block)
+        res = Gcloud.backend.execute(c, options, &block)
         res ? JSON.parse(res) : nil
       end
 
@@ -69,7 +69,11 @@ module Milc
 
       def call_action(action, cmd_args, attrs = nil, &block)
         attr_args = attrs.nil? ? '' : build_attr_args(attrs)
-        __gcloud("#{service} #{resource} #{action} #{cmd_args} #{attr_args}", &block)
+        options =
+          action =~ /\Alist|\Adescribe|\Aget/ ?
+            {returns: :stdout, logging: :stderr} :
+            {returns: :none  , logging: :both}
+        __gcloud("#{service} #{resource} #{action} #{cmd_args} #{attr_args}", options, &block)
       end
 
       def call_update(cmd_args, attrs, &block)

--- a/milc.gemspec
+++ b/milc.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     # spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
   end
 
-  spec.add_runtime_dependency "logger_pipe", "~> 0.3.0"
+  spec.add_runtime_dependency "logger_pipe", "~> 0.3.1"
   spec.add_runtime_dependency "activesupport", "~> 4.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.8"

--- a/spec/milc/base_spec.rb
+++ b/spec/milc/base_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 
 describe Milc::Base do
+  let(:query_options){ {returns: :stdout, logging: :stderr} }
+  let(:ope_options){ {returns: :none, logging: :both} }
 
   CONFIG_PATH = File.expand_path("../sample.yml", __FILE__)
   CONFIG      = YAML.load_file(CONFIG_PATH)
@@ -90,13 +92,13 @@ describe Milc::Base do
     subject{ MgcloudSample.new }
     let(:create_arg_ptn){ %r!gcloud compute networks create #{network1_name}\s+--range \"10.0.0.0\/8\"\s+--format json\s+--project #{project}! }
     it "when not created yet" do
-      expect(LoggerPipe).to receive(:run).with(Milc.logger, find_arg_ptn  , dry_run: be_falsey).and_return([].to_json)
-      expect(LoggerPipe).to receive(:run).with(Milc.logger, create_arg_ptn, dry_run: be_falsey).and_return([].to_json)
+      expect(LoggerPipe).to receive(:run).with(Milc.logger, find_arg_ptn  , query_options.merge(dry_run: be_falsey)).and_return([].to_json)
+      expect(LoggerPipe).to receive(:run).with(Milc.logger, create_arg_ptn,   ope_options.merge(dry_run: be_falsey)).and_return([].to_json)
       subject.run(["-c", CONFIG_PATH])
     end
     it "when already created" do
-      expect(LoggerPipe).to     receive(:run).with(Milc.logger, find_arg_ptn, dry_run: be_falsey).and_return([network1_res].to_json)
-      expect(LoggerPipe).to_not receive(:run).with(Milc.logger, /gcloud compute networks create/, dry_run: be_falsey)
+      expect(LoggerPipe).to     receive(:run).with(Milc.logger, find_arg_ptn, query_options.merge(dry_run: be_falsey)).and_return([network1_res].to_json)
+      expect(LoggerPipe).to_not receive(:run).with(Milc.logger, /gcloud compute networks create/, ope_options.merge(dry_run: be_falsey))
       subject.run(["-c", CONFIG_PATH])
     end
   end
@@ -105,7 +107,7 @@ describe Milc::Base do
     subject{ GcloudSample.new }
     let(:create_arg_ptn){ %r!gcloud compute networks create #{network1_name}\s+--range \"10.0.0.0\/8\"\s+--project #{project}! }
     it do
-      expect(LoggerPipe).to receive(:run).with(Milc.logger, create_arg_ptn, dry_run: be_falsey)
+      expect(LoggerPipe).to receive(:run).with(Milc.logger, create_arg_ptn, ope_options.merge(dry_run: be_falsey))
       subject.run(["-c", CONFIG_PATH])
     end
   end
@@ -114,7 +116,7 @@ describe Milc::Base do
     subject{ JsonGcloudSample.new }
     let(:create_arg_ptn){ %r!gcloud compute networks create #{network1_name}\s+--range \"10.0.0.0\/8\"\s+--format json\s+--project #{project}! }
     it do
-      expect(LoggerPipe).to receive(:run).with(Milc.logger, create_arg_ptn, dry_run: be_falsey)
+      expect(LoggerPipe).to receive(:run).with(Milc.logger, create_arg_ptn, query_options.merge(dry_run: be_falsey))
       subject.run(["-c", CONFIG_PATH])
     end
   end
@@ -122,7 +124,7 @@ describe Milc::Base do
   describe :ansible_playbook do
     subject{ AnsibleSample.new }
     it do
-      expect(LoggerPipe).to receive(:run).with(Milc.logger, /ansible-playbook -i inventory_filename config.yml/, dry_run: be_falsey)
+      expect(LoggerPipe).to receive(:run).with(Milc.logger, /ansible-playbook -i inventory_filename config.yml/, ope_options.merge(dry_run: be_falsey))
       subject.run(["-c", CONFIG_PATH])
     end
   end

--- a/spec/milc/gcloud/compute/instances_spec.rb
+++ b/spec/milc/gcloud/compute/instances_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe "compute instances" do
+  let(:query_options){ {returns: :stdout, logging: :stderr} }
+  let(:ope_options){ {returns: :none, logging: :both} }
 
   let(:project){ "dummy-ghost-333" }
   let(:env_name) { "sandbox99" }
@@ -88,13 +90,13 @@ describe "compute instances" do
     subject{ Milc::Gcloud::Resource.lookup(project, :compute, :instances) }
     describe :find do
       it "found" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([vm1_res].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([vm1_res].to_json)
         r = subject.find(vm1_name)
         expect(r).to eq vm1_res
       end
 
       it "not found" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
         r = subject.find(vm1_name)
         expect(r).to be_nil
       end
@@ -115,13 +117,13 @@ describe "compute instances" do
       # gcloud compute instances create #{env_name}-trdb01 --disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01 device-name=data-#{env_name}-trdb01 mode=rw boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}  --format json --project #{project}
       let(:create_arg_ptn){ %r!gcloud compute instances create #{vm1_name}\s+--disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01 device-name=data-#{env_name}-trdb01 mode=rw boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}\s+--format json\s+--project #{project}! }
       it "when not created yet" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([].to_json)
-        expect(Milc::Gcloud.backend).to receive(:execute).with(create_arg_ptn).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(create_arg_ptn, ope_options).and_return([].to_json)
         subject.create(vm1_name, vm_args)
       end
       it "when already created" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([vm1_res].to_json)
-        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute instances create/)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([vm1_res].to_json)
+        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute instances create/, ope_options)
         subject.create(vm1_name, vm_args)
       end
     end
@@ -137,13 +139,13 @@ describe "compute instances" do
     describe :delete do
       let(:delete_arg_ptn){ %r!gcloud compute instances delete #{vm1_name}\s+--format json\s+--project #{project}! }
       it "when not created yet" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([].to_json)
-        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute instances delete/)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute instances delete/, ope_options)
         subject.delete(vm1_name)
       end
       it "when already created" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([vm1_res].to_json)
-        expect(Milc::Gcloud.backend).to receive(:execute).with(delete_arg_ptn).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([vm1_res].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(delete_arg_ptn, ope_options).and_return([].to_json)
         subject.delete(vm1_name)
       end
     end

--- a/spec/milc/gcloud/compute/networks_spec.rb
+++ b/spec/milc/gcloud/compute/networks_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe "compute networks" do
+  let(:query_options){ {returns: :stdout, logging: :stderr} }
+  let(:ope_options){ {returns: :none, logging: :both} }
 
   let(:project){ "dummy-ghost-333" }
   let(:network1_name) { "network-sandbox99" }
@@ -22,19 +24,19 @@ describe "compute networks" do
     subject{ Milc::Gcloud::Resource.lookup(project, :compute, :networks) }
     describe :find do
       it "found" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([network1_res].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([network1_res].to_json)
         r = subject.find(network1_name)
         expect(r).to eq network1_res
       end
 
       it "not found" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
         r = subject.find(network1_name)
         expect(r).to be_nil
       end
 
       it "using logger_pipe" do
-        expect(LoggerPipe).to receive(:run).with(Milc.logger, find_arg_ptn, dry_run: be_falsey).and_return([network1_res].to_json)
+        expect(LoggerPipe).to receive(:run).with(Milc.logger, find_arg_ptn, query_options.merge(dry_run: be_falsey)).and_return([network1_res].to_json)
         r = subject.find(network1_name)
         expect(r).to eq network1_res
       end
@@ -43,13 +45,13 @@ describe "compute networks" do
     describe :create do
       let(:create_arg_ptn){ %r!gcloud compute networks create #{network1_name}\s+--range \"10.0.0.0\/8\"\s+--format json\s+--project #{project}! }
       it "when not created yet" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([].to_json)
-        expect(Milc::Gcloud.backend).to receive(:execute).with(create_arg_ptn).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(create_arg_ptn, ope_options).and_return([].to_json)
         subject.create(network1_name, range: "\"10.0.0.0/8\"")
       end
       it "when already created" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([network1_res].to_json)
-        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute networks create/)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([network1_res].to_json)
+        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute networks create/, ope_options)
         subject.create(network1_name, range: "\"10.0.0.0/8\"")
       end
     end
@@ -65,13 +67,13 @@ describe "compute networks" do
     describe :delete do
       let(:delete_arg_ptn){ %r!gcloud compute networks delete #{network1_name}\s+--format json\s+--project #{project}! }
       it "when not created yet" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([].to_json)
-        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute networks delete/)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to_not receive(:execute).with(/gcloud compute networks delete/, ope_options)
         subject.delete(network1_name, range: "\"10.0.0.0/8\"")
       end
       it "when already created" do
-        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn).and_return([network1_res].to_json)
-        expect(Milc::Gcloud.backend).to receive(:execute).with(delete_arg_ptn).and_return([].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([network1_res].to_json)
+        expect(Milc::Gcloud.backend).to receive(:execute).with(delete_arg_ptn, ope_options).and_return([].to_json)
         subject.delete(network1_name)
       end
     end


### PR DESCRIPTION
use {returns: :stdout, logging: :stderr} for query commands and use {returns: :none, logging: :both} for other commands by using logger_pipe-0.3.1 
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
