### PR TITLE
CI with latest Ruby (2.0.0, 2.1.6, 2.2.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.0.0
+  - 2.1.6
+  - 2.2.2
 before_install: gem install bundler --version '>= 1.8.0'


### PR DESCRIPTION
Ruby 2.2.2, and 2.1.6, 2.0.0-p645 was released on 2015-04-13,
and Ruby 2.2.2, 2.1.6 is now available on Travis CI.
(but 2.0.0-p645 is not available, 2.0.0 means 2.0.0-p598 currently)
## reviewers
- [x] @akm 
- [x] @nagachika 
