### PR TITLE
separate command setting from logic

### DIFF
--- a/lib/milc.rb
+++ b/lib/milc.rb
@@ -3,10 +3,11 @@ require "milc/version"
 require 'logger'
 
 module Milc
-  autoload :Base, 'milc/base'
-  autoload :Dsl , 'milc/dsl'
+  autoload :Base   , 'milc/base'
+  autoload :Dsl    , 'milc/dsl'
+  autoload :Gcloud , 'milc/gcloud'
 
-  autoload :Gcloud, 'milc/gcloud'
+  autoload :Command, 'milc/command'
 
   class << self
     attr_accessor :dry_run

--- a/lib/milc/base.rb
+++ b/lib/milc/base.rb
@@ -16,10 +16,6 @@ end
 
 module Milc
   module Base
-    include Milc::Dsl::Gcloud
-    include Milc::Dsl::Mgcloud
-
-    include Milc::Dsl::Ansible
 
     def logger
       Milc.logger

--- a/lib/milc/base.rb
+++ b/lib/milc/base.rb
@@ -2,11 +2,8 @@
 
 require "milc"
 
-require 'json'
 require 'erb'
 require 'yaml'
-require 'optparse'
-require 'shellwords'
 
 require 'logger_pipe'
 
@@ -34,28 +31,19 @@ module Milc
       block_given? ? yield(res) : res
     end
 
-    def load_from_yaml(yaml_path)
-      @config = YAML.load_file_with_erb(yaml_path)
-      load_config
-    end
-
-    attr_reader :config
+    attr_accessor :config
     attr_reader :project
 
     def dry_run
       Milc.dry_run
     end
 
+    # overriden
     def load_config
       @project = config['PROJECT'] || ENV['PROJECT']
     end
 
-    def show_help_and_exit1
-      ## シェルスクリプトのUsage
-      $stderr.puts help_message
-      exit 1
-    end
-
+    # overriden
     def help_message
       ## スクリプト名
       cmdname = File.basename($0) # $PROGRAM_NAME を推奨
@@ -63,36 +51,8 @@ module Milc
       "Usage: #{cmdname} -c CONF_FILE"
     end
 
-    def command_options
-      "nVc:" # n と V と c: は必須
-    end
-
+    # overriden
     def load_options(options)
-      if options["c"]
-        load_from_yaml(options["c"])
-      else
-        show_help_and_exit1
-      end
-    end
-
-    def setup(args)
-      # ARGV.getopts については以下を参照
-      # http://d.hatena.ne.jp/zariganitosh/20140819/ruby_optparser_true_power
-      # http://docs.ruby-lang.org/ja/2.1.0/method/OptionParser=3a=3aArguable/i/getopts.html
-      args.extend(OptionParser::Arguable) unless args.is_a?(OptionParser::Arguable)
-      options = args.getopts(command_options)
-      show_help_and_exit1 unless args.empty?
-
-      Milc.dry_run = !!options["n"]
-      Milc.verbose = !!options["V"]
-
-      load_options(options)
-    end
-
-    def run(args)
-      setup(args)
-      process
-      # exit 0
     end
 
   end

--- a/lib/milc/command.rb
+++ b/lib/milc/command.rb
@@ -1,0 +1,57 @@
+# coding: utf-8
+require 'milc'
+
+require 'optparse'
+
+module Milc
+  class Command
+
+    attr_reader :logic
+    def initialize(logic)
+      @logic = logic
+    end
+
+    def run(args)
+      setup(args)
+      logic.process
+      # exit 0
+    end
+
+    def setup(args)
+      # ARGV.getopts については以下を参照
+      # http://d.hatena.ne.jp/zariganitosh/20140819/ruby_optparser_true_power
+      # http://docs.ruby-lang.org/ja/2.1.0/method/OptionParser=3a=3aArguable/i/getopts.html
+      args.extend(OptionParser::Arguable) unless args.is_a?(OptionParser::Arguable)
+      options = args.getopts(command_options)
+      show_help_and_exit1 unless args.empty?
+
+      Milc.dry_run = !!options["n"]
+      Milc.verbose = !!options["V"]
+
+      load_options(options)
+    end
+
+    # overriden
+    def command_options
+      "nVc:" # n と V と c: は必須
+    end
+
+    def show_help_and_exit1
+      ## シェルスクリプトのUsage
+      $stderr.puts logic.help_message
+      exit 1
+    end
+
+    def load_options(options)
+      if options["c"]
+        yaml_path = options["c"]
+        logic.config = YAML.load_file_with_erb(yaml_path)
+        logic.load_config
+      else
+        show_help_and_exit1
+      end
+      logic.load_options(options)
+    end
+
+  end
+end

--- a/lib/milc/dsl/gcloud.rb
+++ b/lib/milc/dsl/gcloud.rb
@@ -1,5 +1,7 @@
 require "milc/dsl"
 
+require 'json'
+
 module Milc::Dsl
   module Gcloud
 

--- a/lib/milc/version.rb
+++ b/lib/milc/version.rb
@@ -1,3 +1,3 @@
 module Milc
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- extract Milc::Command to separate command setting from logic.
- stop Milc::Base include DSL modules
  - include them by the classes use them
- bump up version from 0.1.4 to 0.2.0
## reviewers
- [x] @kumanoryo 
- [x] @minimum2scp 
- [x] @nagachika 
