### PR TITLE
Outout ansible's output to stderr after it fails

### DIFF
--- a/lib/milc/dsl/ansible.rb
+++ b/lib/milc/dsl/ansible.rb
@@ -7,7 +7,13 @@ module Milc::Dsl
       # https://github.com/mitchellh/vagrant/blob/0098b7604d071948fd37b16dd10b87b6df49b624/plugins/provisioners/ansible/provisioner.rb#L58
       command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook #{cmd}"
       command << " -vvvv" if Milc.verbose
-      execute(command, returns: :none, logging: :both, &block)
+      begin
+        execute(command, returns: :none, logging: :both, &block)
+      rescue LoggerPipe::Failure => e
+        $stderr.puts e.buffer.join
+        $stderr.puts("\e[31m[#{e.class.name}] #{e.message}\e[0m")
+        raise e
+      end
       nil
     end
 

--- a/lib/milc/version.rb
+++ b/lib/milc/version.rb
@@ -1,3 +1,3 @@
 module Milc
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/milc/base_spec.rb
+++ b/spec/milc/base_spec.rb
@@ -131,6 +131,19 @@ describe Milc::Base do
       expect(LoggerPipe).to receive(:run).with(Milc.logger, /ansible-playbook -i inventory_filename config.yml/, ope_options.merge(dry_run: be_falsey))
       subject.run(["-c", CONFIG_PATH])
     end
+
+    let(:buf){ %W[foo\r bar\r baz\r] }
+    it "outputs stdout and stderr" do
+      require 'logger_pipe/runner'
+      expect(LoggerPipe).to receive(:run).
+                             with(Milc.logger, /ansible-playbook -i inventory_filename config.yml/, ope_options.merge(dry_run: be_falsey)).
+                             and_raise(LoggerPipe::Failure.new("Error!", buf))
+      expect($stderr).to receive(:puts).with(buf.join)
+      expect($stderr).to receive(:puts).with(/\[LoggerPipe::Failure\] Error\!/)
+      expect{
+        subject.run(["-c", CONFIG_PATH])
+      }.to raise_error(LoggerPipe::Failure)
+    end
   end
 
 end


### PR DESCRIPTION
Before cloudn't see outputs when ansible command fails via ansible_playbook method.
So make ansible_playbook method output them after ansible command fails.
## reviewers
- [x] @minimum2scp 
- [x] @nagachika 
- [x] @kumanoryo 
