### PR TITLE
transition to using comma-separated lists (space-sperarated lists are deprecated)

### DIFF
--- a/lib/milc/gcloud/resource.rb
+++ b/lib/milc/gcloud/resource.rb
@@ -64,7 +64,7 @@ module Milc
       end
 
       def build_sub_attr_args(attrs)
-        attrs.map{|k,v| "#{k.to_s.gsub(/\_/, '-')}=#{v}" }.join(" ")
+        attrs.map{|k,v| "#{k.to_s.gsub(/\_/, '-')}=#{v}" }.join(",")
       end
 
       def call_action(action, cmd_args, attrs = nil, &block)

--- a/lib/milc/version.rb
+++ b/lib/milc/version.rb
@@ -1,3 +1,3 @@
 module Milc
-  VERSION = "0.2.2dev"
+  VERSION = "0.2.2"
 end

--- a/lib/milc/version.rb
+++ b/lib/milc/version.rb
@@ -1,3 +1,3 @@
 module Milc
-  VERSION = "0.2.1"
+  VERSION = "0.2.2dev"
 end

--- a/spec/milc/gcloud/compute/instances_spec.rb
+++ b/spec/milc/gcloud/compute/instances_spec.rb
@@ -108,14 +108,17 @@ describe "compute instances" do
           {name: "#{env_name}-trdb01"     , device_name: "#{env_name}-trdb01"     , mode: "rw", boot: "yes"},
           {name: "data-#{env_name}-trdb01", device_name: "data-#{env_name}-trdb01", mode: "rw", boot: "no" },
         ],
-        zone: "asia-east1-c", machine_type: "n1-standard-4", scopes: "bigquery",
-        network: "network-#{env_name}", tags: "trdb #{env_name}"
+        zone: "asia-east1-c",
+        machine_type: "n1-standard-4",
+        scopes: "bigquery",
+        network: "network-#{env_name}",
+        tags: "trdb,#{env_name}"
       }
     end
 
     describe :create do
-      # gcloud compute instances create #{env_name}-trdb01 --disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01,device-name=data-#{env_name}-trdb01,mode=rw,boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}  --format json --project #{project}
-      let(:create_arg_ptn){ %r!gcloud compute instances create #{vm1_name}\s+--disk name=#{env_name}-trdb01,device-name=#{env_name}-trdb01,mode=rw,boot=yes --disk name=data-#{env_name}-trdb01,device-name=data-#{env_name}-trdb01,mode=rw,boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}\s+--format json\s+--project #{project}! }
+      # gcloud compute instances create #{env_name}-trdb01 --disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01,device-name=data-#{env_name}-trdb01,mode=rw,boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb,#{env_name}  --format json --project #{project}
+      let(:create_arg_ptn){ %r!gcloud compute instances create #{vm1_name}\s+--disk name=#{env_name}-trdb01,device-name=#{env_name}-trdb01,mode=rw,boot=yes --disk name=data-#{env_name}-trdb01,device-name=data-#{env_name}-trdb01,mode=rw,boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb,#{env_name}\s+--format json\s+--project #{project}! }
       it "when not created yet" do
         expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
         expect(Milc::Gcloud.backend).to receive(:execute).with(create_arg_ptn, ope_options).and_return([].to_json)

--- a/spec/milc/gcloud/compute/instances_spec.rb
+++ b/spec/milc/gcloud/compute/instances_spec.rb
@@ -114,8 +114,8 @@ describe "compute instances" do
     end
 
     describe :create do
-      # gcloud compute instances create #{env_name}-trdb01 --disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01 device-name=data-#{env_name}-trdb01 mode=rw boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}  --format json --project #{project}
-      let(:create_arg_ptn){ %r!gcloud compute instances create #{vm1_name}\s+--disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01 device-name=data-#{env_name}-trdb01 mode=rw boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}\s+--format json\s+--project #{project}! }
+      # gcloud compute instances create #{env_name}-trdb01 --disk name=#{env_name}-trdb01 device-name=#{env_name}-trdb01 mode=rw boot=yes --disk name=data-#{env_name}-trdb01,device-name=data-#{env_name}-trdb01,mode=rw,boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}  --format json --project #{project}
+      let(:create_arg_ptn){ %r!gcloud compute instances create #{vm1_name}\s+--disk name=#{env_name}-trdb01,device-name=#{env_name}-trdb01,mode=rw,boot=yes --disk name=data-#{env_name}-trdb01,device-name=data-#{env_name}-trdb01,mode=rw,boot=no --zone asia-east1-c --machine-type n1-standard-4 --scopes bigquery --network network-#{env_name} --tags trdb #{env_name}\s+--format json\s+--project #{project}! }
       it "when not created yet" do
         expect(Milc::Gcloud.backend).to receive(:execute).with(find_arg_ptn, query_options).and_return([].to_json)
         expect(Milc::Gcloud.backend).to receive(:execute).with(create_arg_ptn, ope_options).and_return([].to_json)


### PR DESCRIPTION
With latest Google Cloud SDK (0.9.78),

``` shell
gcloud compute disks create instance-1 \
  --image debian-7 \
  --zone asia-east1-a \
  --project=some-projid-123
gcloud compute instances create instance-1 \
  --disk name=instance-1 mode=rw boot=yes device-name=instance-1 auto-delete=no \
  --machine-type f1-micro \
  --zone asia-east1-a \
  --project=some-projid-123
```

shows warning message:

```
WARNING: We noticed that you are using space-separated lists, which are deprecated. Please transition to using comma-separated lists instead (try "--disk name=instance-1,mode=rw,boot=yes,device-name=instance-1,auto-delete=no"). If you intend to use [mode=rw, boot=yes, device-name=instance-1, auto-delete=no] as positional arguments, put the flags at the end.
```

So, milc should use comma for `--disk` option arguments.
### reviewers
- [x] @akm 
- [x] @nagachika 
